### PR TITLE
moving grants from macro to dbt_project config

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -44,7 +44,9 @@ vars:
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 
 models:
-  
+  +grants:
+    select: ['transformer']
+
   tpch:
     staging:
       +materialized: view

--- a/macros/grant_all_on_schemas.sql
+++ b/macros/grant_all_on_schemas.sql
@@ -1,9 +1,5 @@
 {% macro grant_all_on_schemas(schemas, role) %}
   {% for schema in schemas %}
     grant usage on schema {{ schema }} to role {{ role }};
-    grant select on all tables in schema {{ schema }} to role {{ role }};
-    grant select on all views in schema {{ schema }} to role {{ role }};
-    grant select on future tables in schema {{ schema }} to role {{ role }};
-    grant select on future views in schema {{ schema }} to role {{ role }};
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Updated Snowflake demo project to include the new grant config according to [this task ](https://app.asana.com/0/1201728731723367/1202702501102756/f)

After looking into [how grants work](https://docs.getdbt.com/reference/resource-configs/grants) and [our current recommendations](https://docs.getdbt.com/blog/configuring-grants).

I've removed the select and future select from the macro and used the select config in the dbt_project instead.

I've kept the `grant usage on schema` in the `grant_all_on_schemas` macro & hook since that doesn't seem possible at this point with the grants config.