### PR TITLE
Idea: Managing UDFs with snowpark a way for dryer python code

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -13,7 +13,7 @@ profile: 'tpch'
 # These configurations specify where dbt should look for different types of files.
 # The `models-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!
-model-paths: ["models"]
+model-paths: ["models", "src"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
 seed-paths: ["data"]
@@ -55,7 +55,12 @@ models:
     marts:
       core:
         materialized: table
-      
+
+    utils:
+      materialized: table
+      +schema: python_utils
+      +tags: "python_utils"
+
 seeds:
   tpch:
     snowflake_contract_rates:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from snowflake.snowpark.functions import udf
+
+def model(dbt, session):
+
+    dbt.config(
+        packages = ["pandas"],
+    )
+
+    session.sql('create or replace stage MODELSTAGE').collect()
+
+    @udf(name="mod5", is_permanent=True, stage_location="@MODELSTAGE", replace=True)
+    def mod5(x: int) -> int:
+        return x % 5
+
+    @udf(name="area_of_circle", is_permanent=True, stage_location="@MODELSTAGE", replace=True)
+    def area_of_circle(r: float) -> float:
+        pi = 3.14
+        area = pi * (r * r)
+        return area
+
+    df = pd.read_json('{"function_name":"mod5","location":"MODELSTAGE"}\n{"function_name":"area_of_circle","location":"MODELSTAGE"}', lines=True)
+
+    return df


### PR DESCRIPTION
I was a bit triggered after the initial reaction by one of the folks at our consulting partner Kaito ([See here](https://dbt-labs.slack.com/archives/C01NGTC85C0/p1675345121534099)).

I went on and tried a bunch of stuff and I am now at a point where I want to stop and bring this for discussion because I can imagine this being asked more often in the future. 

It's about a common thing (I guess) that people coding in python are used to. Custom modules allow you to put your code into more digestible and manageable pieces - basically the essence of what dbt helps with when it comes to SQL.

Wonder what others think about my suggestion here. 