### PR TITLE
Move source `freshness` definitions under `config`

### DIFF
--- a/models/staging/jaffle_shop/__jaffle_sources.yml
+++ b/models/staging/jaffle_shop/__jaffle_sources.yml
@@ -9,24 +9,26 @@ sources:
         description: One record per person who has purchased one or more items
       - name: raw_orders
         description: One record per order (consisting of one or more order items)
-        freshness:
-          warn_after:
-            count: 24
-            period: hour
-          # error_after:
-          #   count: 48
-          #   period: hour
+        config:
+          freshness:
+            warn_after:
+              count: 24
+              period: hour
+            # error_after:
+            #   count: 48
+            #   period: hour
         loaded_at_field: ordered_at
       - name: raw_items
         description: Items included in an order
       - name: raw_stores
-        freshness:
-          warn_after:
-            count: 24
-            period: hour
-          # error_after:
-          #   count: 48
-          #   period: hour
+        config:
+          freshness:
+            warn_after:
+              count: 24
+              period: hour
+            # error_after:
+            #   count: 48
+            #   period: hour
         loaded_at_field: opened_at
       - name: raw_products
         description: One record per SKU for items sold in stores

--- a/models/staging/jaffle_shop/src_jaffle_shop.yml
+++ b/models/staging/jaffle_shop/src_jaffle_shop.yml
@@ -16,10 +16,11 @@ sources:
       - name: orders
         identifier: orders
         loaded_at_field: _etl_loaded_at
-        freshness:
-          warn_after:
-            count: 12
-            period: hour
-          error_after:
-            count: 24
-            period: hour
+        config:
+          freshness:
+            warn_after:
+              count: 12
+              period: hour
+            error_after:
+              count: 24
+              period: hour

--- a/models/staging/tpch/tpch_sources.yml
+++ b/models/staging/tpch/tpch_sources.yml
@@ -9,9 +9,10 @@ sources:
     tables:
       - name: orders
         description: main order tracking table
-        freshness: # make this a warning as this is static data
-          warn_after: {count: 6, period: hour}
-          # error_after: {count: 12, period: hour}
+        config:
+          freshness: # make this a warning as this is static data
+            warn_after: {count: 6, period: hour}
+            # error_after: {count: 12, period: hour}
         loaded_at_field: o_orderdate::timestamp
         
         columns:


### PR DESCRIPTION
Having the top level `freshness` definition was causing deprecation warnings, as `freshness` is now supposed to be defined under `config`